### PR TITLE
fix(portfolio): correct BRISA & UFG start date to Jul 2025

### DIFF
--- a/src/data/portfolio.ts
+++ b/src/data/portfolio.ts
@@ -123,7 +123,7 @@ export const workExperience: WorkExperience[] = [
   {
     company: 'BRISA & UFG',
     role: {en: 'Software Engineer', pt: 'Engenheiro de Software'},
-    period: 'Feb 2025 — Dec 2025',
+    period: 'Jul 2025 — Dec 2025',
     logo: '/img/work/brisa.webp',
     monogram: 'BR',
     description: {


### PR DESCRIPTION
The BRISA & UFG residency period was showing **Feb 2025 — Dec 2025**; the correct start is **Jul 2025** (confirmed against LinkedIn). One-line fix in `src/data/portfolio.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)