### PR TITLE
notebook: add DevEx + Linux entries; tidy categories

### DIFF
--- a/notebook/devex/_category_.json
+++ b/notebook/devex/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "DevEx / Platform",
+  "position": 3,
+  "link": {
+    "type": "generated-index",
+    "description": "Developer experience and platform tooling."
+  }
+}

--- a/notebook/devex/reproducible-laravel-devcontainers.md
+++ b/notebook/devex/reproducible-laravel-devcontainers.md
@@ -1,0 +1,105 @@
+---
+id: reproducible-laravel-devcontainers
+title: Reproducible Laravel Dev Environments with Sail + DevContainers
+sidebar_label: Laravel Sail + DevContainers
+description: A one-command, fully reproducible local backend — API, Postgres (with an isolated test database), and a mocked S3 — using DevContainers on top of Laravel Sail.
+---
+
+# Reproducible Laravel Dev Environments with Sail + DevContainers
+
+The goal of this how-to is a backend that a new developer can run with **one action**:
+open the folder in the editor, "Reopen in Container", and get an identical API + database +
+object storage on any machine — Linux, macOS, or Windows.
+
+## The problem it solves
+
+Onboarding to a real backend often stalls on environment drift: a specific PHP/Laravel
+version, one maintainer on macOS and everyone else on Windows, Postgres extensions that
+must exist before the schema loads, and a database dump that won't restore cleanly. Each of
+these is small; together they cost days or weeks. A **DevContainer** turns that tribal setup
+knowledge into a versioned, reproducible path.
+
+## Architecture
+
+Three services on an internal network, orchestrated by the DevContainer:
+
+- **`laravel.dev`** — the API, on a Laravel Sail image (PHP 8.1).
+- **`pgsql`** — PostgreSQL 15. A bootstrap script creates both the main database **and an
+  isolated `_test` database**, so automated tests never touch development data.
+- **`minio`** — a local S3-compatible object store. It mocks AWS S3 so features that upload
+  images run locally with **no real cloud account** — a higher-fidelity environment.
+
+## The DevContainer
+
+`.devcontainer/devcontainer.json` points at the Compose file, selects the app service, and
+runs everything needed on first build:
+
+```jsonc
+{
+  "name": "app-dev",
+  "dockerComposeFile": ["../compose.yaml"],
+  "service": "laravel.dev",
+  "workspaceFolder": "/var/www/html",
+  "remoteUser": "sail",
+  "postCreateCommand": "composer install && php artisan key:generate && php artisan jwt:secret --force && php artisan migrate"
+}
+```
+
+The `postCreateCommand` is the whole trick: on first open the container installs
+dependencies, generates the app and JWT keys, and runs migrations. Nothing manual.
+
+## Isolated test database, by default
+
+The Postgres bootstrap script creates `<db>` and `<db>_test`. `phpunit.xml` runs the suite
+against the test database:
+
+```xml
+<env name="APP_ENV" value="testing"/>
+<env name="DB_DATABASE" value="app_test"/>
+```
+
+Tests are isolated from development data out of the box — and the same setup is ready to run
+in a CI pipeline later.
+
+## Mocking S3 locally with MinIO
+
+Point Laravel's storage at the MinIO endpoint and a bootstrap script creates the bucket and
+its policy, so upload code paths work offline:
+
+```dotenv
+AWS_ENDPOINT=http://minio:9000
+```
+
+The MinIO console (`http://localhost:9001`) lets you inspect uploaded files during
+development.
+
+## Running it
+
+1. `cp .env.example .env` — the example values are already wired to the containers.
+2. Open the folder in VS Code and choose **Dev Containers: Reopen in Container**.
+3. First build runs the `postCreateCommand` automatically; when it finishes, the API is up.
+
+The only host prerequisites are Docker, VS Code, and the Dev Containers extension — no local
+PHP version to match.
+
+## Loading a database dump
+
+From the host, restore a provided dump into the running Postgres container:
+
+```bash
+cat dump.sql | docker exec -i <db_container> pg_restore -U postgres -d app
+```
+
+If the file is a plain `.sql` rather than a native Postgres archive, use `psql` instead of
+`pg_restore`.
+
+## Useful commands (inside the container terminal)
+
+- Run the tests: `php artisan test`
+- Clear cache: `php artisan cache:clear`
+
+## The payoff
+
+Install any PHP version (or none), open the folder, and the full backend — API, database
+with an isolated test schema, and mocked object storage — comes up the same way for
+everyone. Onboarding stops being a meeting and becomes a command.

--- a/notebook/homelab/linux.md
+++ b/notebook/homelab/linux.md
@@ -1,3 +1,0 @@
-# Linux
-
-A good homelab is based on Linux.

--- a/notebook/homelab/wip.md
+++ b/notebook/homelab/wip.md
@@ -1,0 +1,10 @@
+---
+title: Work in Progress
+sidebar_label: Work in Progress
+---
+
+# Homelab — Work in Progress
+
+This section is being rebuilt alongside the homelab's migration to Proxmox VE. Documentation
+will land here as the new architecture takes shape. In the meantime, the story lives on the
+[blog](/blog).

--- a/notebook/linear-algebra/_category_.json
+++ b/notebook/linear-algebra/_category_.json
@@ -1,8 +1,0 @@
-{
-  "label": "Linear Algebra",
-  "position": 2,
-  "link": {
-    "type": "generated-index",
-    "description": "Stydies about Linear Albebra."
-  }
-}

--- a/notebook/linear-algebra/matriz.md
+++ b/notebook/linear-algebra/matriz.md
@@ -1,3 +1,0 @@
-# Matriz
-
-Matrices are the foundation of linear algebra.

--- a/notebook/linux/_category_.json
+++ b/notebook/linux/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Linux",
+  "position": 4,
+  "link": {
+    "type": "generated-index",
+    "description": "Linux and workstation setup."
+  }
+}

--- a/notebook/linux/managing-dotfiles-with-stow.md
+++ b/notebook/linux/managing-dotfiles-with-stow.md
@@ -1,0 +1,121 @@
+---
+id: managing-dotfiles-with-stow
+title: Managing Dotfiles with GNU Stow
+sidebar_label: Dotfiles with GNU Stow
+description: Keep every config file in one versioned Git repository and symlink it into place with GNU Stow — modular, script-free, and reproducible across machines.
+---
+
+# Managing Dotfiles with GNU Stow
+
+The goal: keep every configuration file in a single, Git-versioned repository, and put each
+one where the system expects it with **symlinks** instead of copies. **GNU Stow** does the
+symlinking. Thanks to [Paulo (PauloHFS)](https://github.com/PauloHFS), who pointed me to
+Stow — I researched and implemented the setup below.
+
+My environment for the examples: Arch Linux (Omarchy) with Hyprland, but the technique is
+OS-agnostic.
+
+## What Stow does
+
+Stow is a symlink farm manager. Instead of copying config files into places like
+`~/.config`, you keep them organized in one folder (e.g. `~/dotfiles`) and Stow creates the
+symlinks in the right locations, pointing back at the repository.
+
+Why this is worth it:
+
+- **Centralization** — every important file lives in one Git-versioned folder.
+- **Modularity** — enable or disable one program's config at a time (`stow nvim`) without
+  touching the rest.
+- **Simplicity** — no scripts to move files around; Stow is the whole mechanism.
+
+## Install
+
+On Arch Linux:
+
+```bash
+sudo pacman -S stow
+```
+
+## Repository structure
+
+Each top-level folder is a **package**, and its contents mirror the structure starting from
+`$HOME`:
+
+```text
+~/dotfiles/
+├── hyprland/            <-- package name
+│   └── .config/
+│       └── hypr/
+│           └── hyprland.conf
+├── waybar/
+│   └── .config/
+│       └── waybar/
+│           └── config.jsonc
+└── bash/
+    └── .bashrc          <-- lands directly in $HOME
+```
+
+## Usage
+
+Apply a package (create its symlinks):
+
+```bash
+cd ~/dotfiles
+stow hyprland
+```
+
+That creates `~/.config/hypr/hyprland.conf` as a link pointing into the repository. Remove
+the links again with:
+
+```bash
+stow -D hyprland
+```
+
+## Resolving conflicts on a fresh machine
+
+A freshly installed system already ships default config files, and Stow refuses to
+overwrite real files (to avoid data loss), so `stow` errors out when a target exists. Two
+ways to resolve it:
+
+**1. The "git trick" (best for migrations).** Let the repository win, then restore its
+original contents:
+
+```bash
+stow --adopt *   # WARNING: this overwrites the repo's files with the machine's current ones
+git restore .    # bring the repo's versions back; $HOME now reflects the repository
+```
+
+Because Stow turned the `$HOME` files into links, restoring the repo makes `$HOME`
+immediately reflect what's in Git.
+
+**2. Manual cleanup (more cautious).** Delete the originals first, then stow:
+
+```bash
+rm ~/.bashrc
+rm -rf ~/.config/hypr
+cd ~/dotfiles && stow *
+```
+
+## Per-machine variants with Git branches
+
+Different machines need slightly different configs — a desktop has monitor layouts a laptop
+doesn't, and so on. I keep that variation in **branches** rather than in conditionals:
+
+- `main` — desktop (monitor setup and related tweaks).
+- a separate branch (e.g. `notebook`) — the laptop variant.
+
+On each machine you check out the branch that matches it, then stow. Shared config stays
+common; only the machine-specific parts diverge, and Git makes the difference explicit and
+reviewable.
+
+## Tips learned the hard way
+
+- **Avoid absolute symlinks inside the repo** (links pointing at `/home/<user>/...`). They
+  break on machines where the username differs. If you hit `absolute symlink` errors, delete
+  the link in the repo and keep a real file or a relative link.
+- **Watch for config version drift** when moving between machines — a program may rename a
+  parameter between versions. Validate after stowing; for Hyprland, for example:
+
+  ```bash
+  hyprctl configerrors
+  ```


### PR DESCRIPTION
## What
- **`notebook/devex/`** (new category "DevEx / Platform") — *Reproducible Laravel Dev Environments with Sail + DevContainers*.
- **`notebook/linux/`** (new category "Linux") — *Managing Dotfiles with GNU Stow* (credits Paulo / PauloHFS).
- **Removed** the `linear-algebra/` placeholder category (untouched stub).
- **Homelab:** replaced the `linux.md` placeholder with a single **Work in Progress** page (also resolves the name clash with the new `linux/` category).

Both entries are de-identified / sanitized (no employer or personal specifics). Sidebar is autogenerated, so the structure updates automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)