### PR TITLE
notebook: home index, menu-only categories, new Prism themes

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -87,8 +87,8 @@ const config: Config = {
       copyright: `Copyright © ${new Date().getFullYear()} João Pedro Ribeiro Barbosa.`,
     },
     prism: {
-      theme: prismThemes.github,
-      darkTheme: prismThemes.dracula,
+      theme: prismThemes.jettwaveLight,
+      darkTheme: prismThemes.vsDark,
     },
   } satisfies Preset.ThemeConfig,
 };

--- a/notebook/devex/_category_.json
+++ b/notebook/devex/_category_.json
@@ -1,8 +1,4 @@
 {
   "label": "DevEx / Platform",
-  "position": 3,
-  "link": {
-    "type": "generated-index",
-    "description": "Developer experience and platform tooling."
-  }
+  "position": 3
 }

--- a/notebook/homelab/_category_.json
+++ b/notebook/homelab/_category_.json
@@ -1,8 +1,4 @@
 {
   "label": "HomeLab",
-  "position": 2,
-  "link": {
-    "type": "generated-index",
-    "description": "My homelab experiences."
-  }
+  "position": 2
 }

--- a/notebook/intro.md
+++ b/notebook/intro.md
@@ -3,6 +3,14 @@ sidebar_position: 1
 slug: /
 ---
 
-# My Notebook
+# Notebook
 
-Here you will find a correct documentation of the things that I've done.
+A technical knowledge base — how-tos, notes, and lessons from the things I build and study.
+Written to be reproducible: if it's documented here, you (or future me) should be able to
+follow it end to end.
+
+Pick a topic from the sidebar:
+
+- **DevEx / Platform** — developer experience and platform tooling.
+- **Linux** — Linux and workstation setup.
+- **Homelab** — my self-hosted infrastructure (work in progress).

--- a/notebook/linux/_category_.json
+++ b/notebook/linux/_category_.json
@@ -1,8 +1,4 @@
 {
   "label": "Linux",
-  "position": 4,
-  "link": {
-    "type": "generated-index",
-    "description": "Linux and workstation setup."
-  }
+  "position": 4
 }


### PR DESCRIPTION
## What
- **Home page (`notebook/intro.md`)** — replaced the placeholder one-liner with a proper index (short welcome + topic list). Since categories no longer have index pages, this is now the single orientation hub. Also fixes the awkward "a correct documentation" phrasing.
- **Categories as menu items** — removed the `generated-index` link from the `homelab`, `devex`, and `linux` `_category_.json`, so a category is a collapsible sidebar group with no dedicated landing page (per the requested behavior).
- **Prism themes** — code blocks now use `jettwaveLight` (light mode) / `vsDark` (dark mode).

No new links added; the autogenerated sidebar and the GitHub Actions build handle the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)