### PR TITLE
feat: own og:image for the blog index (/blog)

### DIFF
--- a/src/theme/BlogListPage/index.tsx
+++ b/src/theme/BlogListPage/index.tsx
@@ -1,0 +1,21 @@
+import React, {type ReactNode} from 'react';
+import BlogListPage from '@theme-original/BlogListPage';
+import type BlogListPageType from '@theme/BlogListPage';
+import type {WrapperProps} from '@docusaurus/types';
+import {PageMetadata} from '@docusaurus/theme-common';
+
+type Props = WrapperProps<typeof BlogListPageType>;
+
+/**
+ * Wrapper da index do blog só para dar a ela um og:image próprio.
+ * Sem isso, `/blog` herda o og:image default do site (o card do portfólio),
+ * fazendo o preview do link da home do blog ficar igual ao do portfólio.
+ */
+export default function BlogListPageWrapper(props: Props): ReactNode {
+  return (
+    <>
+      <PageMetadata image="/img/og-blog.png" />
+      <BlogListPage {...props} />
+    </>
+  );
+}


### PR DESCRIPTION
**Problem:** on LinkedIn Featured, the blog link (`/blog`) showed the **same** thumbnail as the portfolio, because the blog **index** inherits the site default og:image (`og-portfolio.png`). The `og-blog.png` from #16 was only on the Proxmox **post**, not the index.

**Fix:** swizzle-wrap `@theme/BlogListPage` and inject `PageMetadata image="/img/og-blog.png"` so `/blog` has its own card. Also fixes the link preview wherever the blog homepage is shared.

Standard `swizzle --wrap` pattern (Docusaurus 3.9). Build validated by the deploy workflow on merge.

**After merge/deploy:** featuring `https://joao1barbosa.github.io/blog` shows the blog card, distinct from the portfolio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)