### PR TITLE
notebook: list Testing on home + refine pyramid diagram

### DIFF
--- a/notebook/intro.md
+++ b/notebook/intro.md
@@ -12,5 +12,6 @@ follow it end to end.
 Pick a topic from the sidebar:
 
 - **DevEx / Platform** — developer experience and platform tooling.
+- **Testing** — software testing fundamentals, from the pyramid to TDD.
 - **Linux** — Linux and workstation setup.
 - **Homelab** — my self-hosted infrastructure (work in progress).

--- a/notebook/testing/types-of-tests-and-the-pyramid.md
+++ b/notebook/testing/types-of-tests-and-the-pyramid.md
@@ -27,15 +27,13 @@ The pyramid encodes a trade-off. As you move up, tests get **slower, more expens
 fragile** — so you write fewer of them.
 
 ```
-                 ╱╲
-                ╱  ╲                ▲
-               ╱ E2E╲               │  slower
-              ╱──────╲              │  costlier
-             ╱ Integr.╲             │  more fragile
-            ╱──────────╲            │
-           ╱    Unit     ╲          │  (fewer at the top,
-          ╱──────────────╲         │   more at the bottom)
-         ╱________________╲         │
+          ┌───────┐          ▲
+          │  E2E  │          │  slower
+       ┌──┴───────┴──┐       │  costlier
+       │ Integration │       │  more fragile
+    ┌──┴─────────────┴──┐    │
+    │       Unit        │    │  (fewer at the top,
+    └───────────────────┘    │   more at the bottom)
 ```
 
 The rule of thumb: **many unit tests, some integration tests, few E2E tests.** That shape keeps the


### PR DESCRIPTION
Follow-up to the Testing series (#20, merged).

- **Home (`intro.md`)** now lists the new **Testing** category alongside the others.
- **Pyramid diagram** in *Types of Tests & the Testing Pyramid* swapped for a clearer stacked-box pyramid with the side arrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)