### PR TITLE
notebook: fix Testing sidebar order + source attribution

### DIFF
--- a/notebook/testing/test-driven-development.md
+++ b/notebook/testing/test-driven-development.md
@@ -2,6 +2,7 @@
 id: test-driven-development
 title: Test-Driven Development (TDD)
 sidebar_label: TDD
+sidebar_position: 3
 description: The red-green-refactor loop that turns tests into a design tool — write a failing test first, make it pass with the minimum code, then improve — plus what separates a good test from a brittle one.
 ---
 
@@ -43,3 +44,7 @@ Beyond FIRST, a good test:
 Done well, TDD produces a design shaped by how the code is actually used, and a suite of tests that
 are fast, isolated, and honest about failure. The tests stop being a chore you add afterward and
 become the thing that drives the code into shape.
+
+---
+*Studied from freeCodeCamp's [Software Testing with Playwright](https://www.freecodecamp.org/news/software-testing-with-playwright/)
+course. The "what makes a good test" section (FIRST) is standard practice added for completeness.*

--- a/notebook/testing/types-of-tests-and-the-pyramid.md
+++ b/notebook/testing/types-of-tests-and-the-pyramid.md
@@ -2,6 +2,7 @@
 id: types-of-tests-and-the-pyramid
 title: Types of Tests and the Testing Pyramid
 sidebar_label: Types & the Pyramid
+sidebar_position: 2
 description: The three test scopes — unit, integration, and end-to-end — how the testing pyramid balances them, and the specialized test types (smoke, regression, performance, security, accessibility) that sit alongside.
 ---
 
@@ -59,4 +60,4 @@ where they earn their cost, and add specialized types as the risk demands.
 
 ---
 *Studied from freeCodeCamp's [Software Testing with Playwright](https://www.freecodecamp.org/news/software-testing-with-playwright/)
-course ([video](https://www.youtube.com/watch?v=u6QfIXgjwGQ)).*
+course.*

--- a/notebook/testing/why-we-test.md
+++ b/notebook/testing/why-we-test.md
@@ -2,6 +2,7 @@
 id: why-we-test
 title: Why We Test
 sidebar_label: Why We Test
+sidebar_position: 1
 description: Software changes constantly, and tests are the safety net that keeps each change from silently breaking what already worked — plus the ROI case for writing them.
 ---
 
@@ -65,5 +66,5 @@ convert "I hope this still works" into "the suite says it works," on every commi
 hope to evidence, is the point.
 
 ---
-*Studied from freeCodeCamp's [Software Testing with Playwright](https://www.freecodecamp.org/news/software-testing-with-playwright/)
-course ([video](https://www.youtube.com/watch?v=u6QfIXgjwGQ)).*
+*Sources: freeCodeCamp's [Software Testing with Playwright](https://www.freecodecamp.org/news/software-testing-with-playwright/)
+course, and [this video](https://www.youtube.com/watch?v=u6QfIXgjwGQ) on why we test.*


### PR DESCRIPTION
Follow-up fixes to the Testing series.

- **Sidebar order** — the entries were sorting alphabetically (TDD → Types → Why). Pinned `sidebar_position` 1/2/3 so they read in the intended logical order: **Why We Test → Types & the Pyramid → TDD**.
- **Sources** — the YouTube video is a *separate* source and only applies to **Why We Test**. Removed it from the other entries; entries 2 and 3 now cite just the freeCodeCamp course.

🤖 Generated with [Claude Code](https://claude.com/claude-code)