### PR TITLE
portfolio: tighten FX Remittance Ledger description

### DIFF
--- a/src/data/portfolio.ts
+++ b/src/data/portfolio.ts
@@ -233,21 +233,16 @@ export const projects: Project[] = [
     description: {
       en:
         'An event-sourced vertical slice of an FX remittance pipeline (BRL → USD over crypto rails), ' +
-        'built as a take-home. A single FxOperation aggregate moves through six asynchronous steps — ' +
-        'quote, deposit, compliance, conversion, settlement, reconcile — each emitting an immutable, ' +
-        'past-tense fact. The engineering lives in the deviations: expired quote windows, conversion ' +
-        'slippage recorded rather than halted, idempotent webhooks that never pay twice, and a ' +
-        'reconciliation that can fail. Money is always integer cents; the ledger is a double-entry ' +
-        'projection rebuilt by replay, proven by a Pest suite of business scenarios.',
+        'built as a take-home: a single FxOperation aggregate moves through six asynchronous steps — ' +
+        'quote, deposit, compliance, conversion, settlement, reconcile — each emitting an immutable ' +
+        'fact. Money is always integer cents, webhooks are idempotent at the aggregate, and the ledger ' +
+        'is a double-entry projection proven by a Pest suite of business scenarios.',
       pt:
         'Uma fatia vertical event-sourced de um pipeline de remessa cambial (BRL → USD sobre trilhos ' +
-        'de cripto), feita como desafio técnico. Um único agregado FxOperation percorre seis passos ' +
+        'de cripto), feita como desafio técnico: um único agregado FxOperation percorre seis passos ' +
         'assíncronos — cotação, depósito, compliance, conversão, liquidação, reconciliação — cada um ' +
-        'emitindo um fato imutável no passado. A engenharia mora nos desvios: janelas de cotação ' +
-        'expiradas, slippage de conversão registrado em vez de interrompido, webhooks idempotentes que ' +
-        'nunca pagam duas vezes e uma reconciliação que pode reprovar. Dinheiro é sempre centavos ' +
-        'inteiros; o ledger é uma projeção double-entry reconstruída por replay, provada por uma suíte ' +
-        'Pest de cenários de negócio.',
+        'emitindo um fato imutável. Dinheiro é sempre centavos inteiros, webhooks são idempotentes no ' +
+        'agregado e o ledger é uma projeção double-entry provada por uma suíte Pest de cenários de negócio.',
     },
     tags: ['PHP', 'Laravel', 'Event Sourcing', 'PostgreSQL', 'Pest', 'Docker'],
   },


### PR DESCRIPTION
## O que muda

Encurta a descrição do **FX Remittance Ledger** (em `src/data/portfolio.ts`) de **6 frases para 2**, alinhando à objetividade dos demais cards de projeto.

Mantém os sinais-chave — event sourcing, pipeline de 6 passos, centavos inteiros, webhooks idempotentes, ledger double-entry, suíte Pest — e corta a elaboração sobre os "desvios".

Cópia bilíngue (en/pt) atualizada nas duas.

## Verificação

- `yarn typecheck` ✅ 0 erros.

Público → via PR (nunca push direto), AGENTS.md §2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)